### PR TITLE
Added the Carbon_Flux notebook

### DIFF
--- a/examples/Carbon_Flux.ipynb
+++ b/examples/Carbon_Flux.ipynb
@@ -1,0 +1,349 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Carbon Monitoring Project"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import holoviews as hv\n",
+    "import pandas as pd\n",
+    "hv.extension('bokeh')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This notebook aims to visualize the data used in the carbon monitoring project [nee_data_fusion](https://github.com/greyNearing/nee_data_fusion/) using Python tools. The goal is to establish how the relevant ML workflow can be expressed in Python.\n",
+    "\n",
+    "To run this notebook, you will need to symlink the `data` directory of the [nee_data_fusion](https://github.com/greyNearing/nee_data_fusion/) to `flux_data` in the `examples` directory of `EarthML`. In addition, you will need `RSIF_2007_2016_05N_01L.mat` in the `examples` directory which you can download from https://gentinelab.eee.columbia.edu/content/datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Loading FluxNet data ``extract_fluxnet.m``\n",
+    "\n",
+    "[FluxNet](http://fluxnet.fluxdata.org/) is a worldwide collection of sensor stations that record a number of local variables relating to atmospheric conditions, solar flux and soil moisture. The data is the [nee_data_fusion](https://github.com/greyNearing/nee_data_fusion/) repository is expressed as a collection of CSV files where the site names are expressed in the filenames."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# %read in FluxNet CSVs and replace NaNs with zeros\n",
+    "\n",
+    "import os\n",
+    "sites = [fname.split('_')[1] for fname in os.listdir('./flux_data/dailies/')]\n",
+    "\n",
+    "latlon = pd.read_csv('./flux_data/latlon.csv', header=None, names=['site', 'lat', 'lon'])\n",
+    "\n",
+    "def site_lat_lon(latlon, site):\n",
+    "    location = latlon[latlon['site'] == site]\n",
+    "    if 0 in [len(location['lat']), len(location['lat'])]:\n",
+    "        return None, None\n",
+    "    return float(location['lat']), float(location['lon'])\n",
+    "\n",
+    "\n",
+    "def load_fluxnet_site(site):\n",
+    "    # dataRaw(dataRaw <= -9990) = 0/0;\n",
+    "    # NaN -> zero\n",
+    "    prefix = 'FLX_{site}_FLUXNET'.format(site=site)\n",
+    "    filename = [fname for fname in os.listdir('./flux_data/dailies/') if fname.startswith(prefix)][0]\n",
+    "    raw_daily = pd.read_csv('./flux_data/dailies/{filename}'.format(filename=filename))    \n",
+    "    derived_cols = ['YEAR','DOY']\n",
+    "    fluxcols = ['P_ERA','TA_ERA','PA_ERA','SW_IN_ERA','LW_IN_ERA'\n",
+    "    ,'WS_ERA','LE_F_MDS','H_F_MDS','NEE_CUT_USTAR50','NEE_VUT_USTAR50',\n",
+    "    'SWC_F_MDS_1','SWC_F_MDS_2','SWC_F_MDS_3','TS_F_MDS_1','TS_F_MDS_2'\n",
+    "    'TS_F_MDS_3','VPD_ERA','GPP_DT_VUT_USTAR50','GPP_DT_CUT_USTAR50']\n",
+    "    available = [col for col in fluxcols if col in raw_daily.columns]\n",
+    "    return raw_daily[['TIMESTAMP']+available]\n",
+    "\n",
+    "\n",
+    "def map_to_days(data):\n",
+    "    return data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dailies = load_fluxnet_site(sites[0])\n",
+    "print('Example FLUXNET data for site {site}:'.format(site=sites[0]))\n",
+    "dailies.head()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "Many of the FluxNet variables are expressed relative to a historical reference called ERA: \n",
+    "\n",
+    "* ERA-15: December 1978 to February 1994.\n",
+    "* ERA-40: Reanalysis from September 1957 through August 2002\n",
+    "  \n",
+    "Relevant links: [ERA](https://en.wikipedia.org/wiki/ECMWF_re-analysis) and [NCAR_Reanalysis](https://en.wikipedia.org/wiki/NCEP/NCAR_Reanalysis).\n",
+    "\n",
+    " \n",
+    "The goal in the matlab code is to build a super-array ``allData`` that spans 8766 Days x 22 Variables and 209 sites. Note that the 8766 span is derived from the *FluxNet* data not ERA. In the repository, I see 210 files with 21 variables. Some of the key variables:\n",
+    "\n",
+    "* TIMESTAMP (Parsed out): YYYYMMDDHHMM\tISO timestamp – short format\n",
+    "* YEAR: Self explanatory\n",
+    "* DOY: Day of year.\n",
+    "\n",
+    "Here are some of the relevant FluxNet variables recorded at each site. The definitions may be found [here](http://fluxnet.fluxdata.org/data/fluxnet2015-dataset/fullset-data-product/):\n",
+    "   \n",
+    "* P_ERA : Precipitation, downscaled from ERA, linearly regressed using measured only site data\n",
+    "* TA_ERA: Air temperature, downscaled from ERA, linearly regressed using measured only site data\n",
+    "* PA_ERA: Atmospheric pressure, downscaled from ERA, linearly regressed using measured only site data\n",
+    "* SW_IN_ERA : Shortwave radiation, incoming, downscaled from ERA, linearly regressed using measured only site data (negative values set to zero)\n",
+    "* LW_IN_ERA : Longwave radiation, incoming, downscaled from ERA, linearly regressed using measured only site data\n",
+    "* WS_ERA: Wind speed, downscaled from ERA, linearly regressed using measured only site data\n",
+    "* SWC_F_MDS_1/2/3: Soil water content, gapfilled with MDS (numeric index “#” increases with the depth, 1 is shallowest)\n",
+    "* TS_F_MDS_1/2/3: Soil temperature, gapfilled with MDS (numeric index “#” increases with the depth, 1 is shallowest)\n",
+    "* VPD_ERA:  Vapor Pressure Deficit, downscaled from ERA, linearly regressed using measured only site data\n",
+    "\n",
+    "We'll use the above variables to predict:\n",
+    "\n",
+    "* NEE_CUT_USTAR50 : Net Ecosystem Exchange, using Constant Ustar Threshold (CUT) across years, from 50 percentile of USTAR threshold\n",
+    "* NEE_VUT_USTAR50: Net Ecosystem Exchange, using Variable Ustar Threshold (VUT) for each year, from 50 percentile of USTAR threshold\n",
+    "\n",
+    "Other variables should not be included as features, either because they are derived from NEE:\n",
+    "\n",
+    "* GPP_DT_VUT_USTAR50: Gross Primary Production, from Daytime partitioning method, based on NEE_VUT_USTAR50\n",
+    "* GPP_DT_CUT_USTAR50: Gross Primary Production, from Daytime partitioning method, based on NEE_CUT_USTAR50\n",
+    "\n",
+    "or because there is no suitable proxy for them in the satellite data:\n",
+    "\n",
+    "* LE_F_MDS: Latent heat flux, gapfilled using MDS method\n",
+    "* H_F_MDS: Sensible heat flux, gapfilled using MDS method\n",
+    "\n",
+    "\n",
+    "Here, we will focus on predicting ``NEE_CUT_USTAR50``. \n",
+    "\n",
+    "Hypothesis : RSIF is more about vegetation than solar flux. Idea is that RSIF reflects carbon capture by vegetation.\n",
+    "\n",
+    "NEE: Soil flux and photosynthesis of carbon.\n",
+    "Note: Not trying to separate these contributions.\n",
+    "Goal: Finding features. Adding features."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Adding RSIF data ``collocate_data_types.m``\n",
+    "\n",
+    "RSIF is the 'Reconstructed Solar Induced Fluorescence' expressing solar energy flux (power) per meter squared arriving on the Earth's surface derived from a vegetation signal."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import scipy.io\n",
+    "rsif = scipy.io.loadmat('RSIF_2007_2016_05N_01L.mat')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "\n",
+    "The goal now is to add the RSIF time series added at positions of stations, then normalize the time dimension (resample to make the data sets have the same temporal sampling) and finally to perform a linear regression analysis on the combined data.\n",
+    "\n",
+    "Note that the matlab file reference above was downloaded from https://gentinelab.eee.columbia.edu/content/datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%opts Image [width=700 height=500 clipping_colors={'NaN': 'gray'}] Points (marker='x' color='cyan')\n",
+    "\n",
+    "mdata = rsif['RSIF'] # NaNs outside of land area.\n",
+    "def rsif_image(day):\n",
+    "    return hv.Image(mdata[:,:,day], kdims=['lon', 'lat'], vdims=['RSIF'], bounds=(-180,-90,180,90))\n",
+    "\n",
+    "rsif_dmap = hv.DynamicMap(rsif_image, kdims=['day']).redim.values(day=range(mdata.shape[2]))\n",
+    "raw_site_positions = {site:site_lat_lon(latlon, site) for site in sites}\n",
+    "site_positions = {site:(lon,lat) for (site, (lat,lon)) in raw_site_positions.items() if None not in (lat,lon)}\n",
+    "rsif_dmap * hv.Points(site_positions.values())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "* Algorithm might be useful: Smoothing?\n",
+    "* Mismatched temporospatial satellite imagery.\n",
+    "\n",
+    "1. Timestamp per lat/lon. Comes with triples. \n",
+    "2. Polar: e.g 1pm local time.\n",
+    "3. Global (processed product?)\n",
+    "\n",
+    "https://science.nasa.gov/earth-science/earth-science-data/data-processing-levels-for-eosdis-data-products\n",
+    "\n",
+    "1. Level 0: Raw data (direct sensor flux). Highest resolution. Minimal model - good for ML.\n",
+    "2. Level 1: Sensor geometry.\n",
+    "3. Level 2: spatial regridding  \n",
+    "4. Level 3: check: physical variable. Primary science product.\n",
+    "5. Level 4: check: model added value.\n",
+    "\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Sampling the RSIF signal at the sites"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "tables = []\n",
+    "for day in range(mdata.shape[2]):\n",
+    "    image = rsif_dmap.select(day=day)\n",
+    "    table = image.sample(samples=site_positions.values())\n",
+    "    tables.append(table.add_dimension('site', 0, site_positions.keys()))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "tabulated = hv.HoloMap({day:tables[day] for day in range(mdata.shape[2])}, kdims=['Day'])\n",
+    "tabulated"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Viewing the RSIF time series per site"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "site_RSIF = tabulated.table().to(hv.Curve, 'Day', 'RSIF').drop_dimension(['lat', 'lon'])\n",
+    "site_RSIF"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### biweekly_averaging.m\n",
+    "\n",
+    "'RSIF' is put onto the same time sampling as the fluxnet data, adding an 'RSIF' field to the fluxnet dataframe for each site."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### main_lr_fluxnet.m\n",
+    "\n",
+    "\n",
+    "Finding the informative variables.\n",
+    "\n",
+    "Main step:\n",
+    "\n",
+    "```\n",
+    "model{s} = stepwiselm(X,y,''constant'',''Criterion'',''aic'',''Upper'',''linear'')\n",
+    "```\n",
+    "\n",
+    "Using [stepwiselm](https://uk.mathworks.com/help/stats/stepwiselm.html):\n",
+    "\n",
+    "```\n",
+    "mdl = stepwiselm(X,y,modelspec) creates a linear model of the responses y to the predictor variables in the data matrix X, using stepwise regression to add or remove predictors. modelspec is the starting model for the stepwise procedure.\n",
+    "```\n",
+    "\n",
+    "Where ``allData`` is the table (effectively the dataframe):\n",
+    "\n",
+    "```\n",
+    "cols= [3:11,14:22];\n",
+    "X = allData(:,cols,s);\n",
+    "y = allData(:,12,s);\n",
+    "```\n",
+    "\n",
+    "* 3:11 : 'LAT','LON','P_ERA','TA_ERA','PA_ERA','SW_IN_ERA','LW_IN_ERA','WS_ERA','LE_F_MDS'\n",
+    "* 12: 'H_F_MDS' (Sensible heat flux, gapfilled using MDS method)\n",
+    "\n",
+    "Check. NEE is the desired predicted. Column 13."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### main_ann_fluxnet.m\n",
+    "\n",
+    "Main step for size ``s`` in ``trainANN`` using [``train``](https://uk.mathworks.com/help/nnet/ref/train.html) in the neural network toolbox:\n",
+    "\n",
+    "```\n",
+    "% net = fitnet(parms.nodes,parms.trainFcn);\n",
+    "net = feedforwardnet(parms.nodes,parms.trainFcn);\n",
+    "[net,~] = train(net,x,t);\n",
+    "```\n",
+    "\n",
+    "```\n",
+    "Xdex= [2:10,15,18,21,24];\n",
+    "Ydex = 13;\n",
+    "```\n",
+    "\n"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}


### PR DESCRIPTION
This notebook is work in progress that is based on the work in [nee_data_fusion](https://github.com/greyNearing/nee_data_fusion). As such, this notebook relies on the files available in that repository which can be made accessible using a suitable symbolic link in the `examples` directory. The RSIF `.mat` file is also required.

Currently the goal of this notebook is as follows:

1. Capture an understanding of the science and goals behind the carbon monitoring project.
2. Show how the data munging required can be achieved easily in Python.
3. Demonstrate how this data can be easily visualized.
4. Demonstrate the ML component of the task.

Currently the first three tasks are partially completed with ongoing work on the 4th step.