### PR TITLE
Updates to Walker Lake for latest intake-xarray.

### DIFF
--- a/examples/Walker_Lake.ipynb
+++ b/examples/Walker_Lake.ipynb
@@ -74,33 +74,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Enable intake logging to see progress as the files download. Download progress bar coming soon!\n",
-    "\n",
-    "import logging\n",
-    "logger = logging.getLogger('intake')\n",
-    "logging.basicConfig()\n",
-    "logger.setLevel(logging.DEBUG)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "cat = intake.open_catalog('catalog.yml')\n",
     "l5 = cat.l5()\n",
     "L5_img = l5.read_chunked()\n",
-    "print(L5_img)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "L5_img = L5_img.squeeze(dim='band', drop=True)\n",
     "L5_img"
    ]
   },
@@ -112,8 +88,7 @@
    "source": [
     "l8 = cat.l8()\n",
     "L8_img = l8.read_chunked()\n",
-    "L8_img = L8_img.squeeze(dim='band', drop=True)\n",
-    "print(L8_img)"
+    "L8_img"
    ]
   },
   {
@@ -178,7 +153,8 @@
    "source": [
     "L5_img.data[L5_img.data==-9999] = np.NaN  # Replace the -9999\n",
     "ndvi5_array = (L5_img[4]-L5_img[3])/(L5_img[4]+L5_img[3])\n",
-    "ndvi5 = ndvi5_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]"
+    "ndvi5 = ndvi5_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]\n",
+    "client.persist(ndvi5)"
    ]
   },
   {
@@ -198,7 +174,8 @@
    "source": [
     "L8_img.data[L8_img.data==-9999] = np.NaN  # Replace the -9999\n",
     "ndvi8_array = (L8_img[4]-L8_img[3])/(L8_img[4]+L8_img[3])\n",
-    "ndvi8 = ndvi8_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]"
+    "ndvi8 = ndvi8_array.to_dataset(name='ndvi')[['x','y', 'ndvi']]\n",
+    "client.persist(ndvi8)"
    ]
   },
   {

--- a/examples/catalog.yml
+++ b/examples/catalog.yml
@@ -12,7 +12,7 @@ sources:
         band: 1
         x: 256
         y: 256
-      concat_dim: concat_dim
+      concat_dim: band
       storage_options: {'anon': True}
   l8:
     description: Images contain Landsat Surface Reflectance Level-2 Science Product L5.
@@ -27,7 +27,7 @@ sources:
         band: 1
         x: 256
         y: 256
-      concat_dim: concat_dim
+      concat_dim: band
       storage_options: {'anon': True}
   landsat_sample:
     description: Sample Landsat image.


### PR DESCRIPTION
The latest version of `intake-xarray` 0.2.2 passes the concat_dim specified in the catalog to rasterio.  This avoids the need to call `squeeze` since the bands are already loaded correctly.