### PR TITLE
Fixes walker lake

### DIFF
--- a/examples/topics/Walker_Lake.ipynb
+++ b/examples/topics/Walker_Lake.ipynb
@@ -254,7 +254,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "if summed.data.isnull().all():\n",
+    "if summed.data.ndvi.isnull().all():\n",
     "    res = 100\n",
     "    x = np.arange(min(ndvi5.x.min(), ndvi8.x.min()), max(ndvi5.x.max(), ndvi8.x.max()), res)\n",
     "    y = np.arange(min(ndvi5.y.min(), ndvi8.y.min()), max(ndvi5.y.max(), ndvi8.y.max()), res)\n",


### PR DESCRIPTION
Works with pytest and with big version now.

@jlstevens was seeing errors like:

```python-traceback
~/miniconda3/envs/earthml-dev/lib/python3.6/site-packages/xarray/core/missing.py in _assert_single_chunk(var, axes)
   382             raise NotImplementedError(
   383                 'Chunking along the dimension to be interpolated '
--> 384                 '({}) is not yet supported.'.format(axis))
   385
   386

NotImplementedError: Chunking along the dimension to be interpolated (0) is not yet supported.
NotImplementedError: Chunking along the dimension to be interpolated (0) is not yet supported.
```