### PR TITLE
Fixing up docs formatting

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -53,8 +53,8 @@ jobs:
         - source activate earthml
         - doit env_capture
         - git checkout -b deploy-${TRAVIS_BRANCH}
-        - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated
-        - git checkout evaluated -- doc  # all large evaluated notebooks and their json files should be checked in to this branch
+        - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated # all large evaluated notebooks and their json files should be checked in to this branch
+        - git checkout evaluated -- 'doc/topics/*.json' 'doc/topics/*.json' 'doc/tutorial/*.json' 'doc/topics/*.json'
       script:
         - nbsite generate-rst --org pyviz-topics --project-name earthml --offset 1 --nblink=top
         - nbsite build --what=html --output=builtdocs

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -4,7 +4,7 @@ EarthML
 
 .. raw:: html
 
-   <div style="width: 65%; float:left">
+   <div style="max-width: 1200; float:left">
 
 
 **Machine learning and visualization in Python for Earth science**
@@ -16,33 +16,37 @@ libraries are suitable for which tasks. The EarthML project helps to:
    - Demonstrate how to use Python tools for machine learning and analysis in the earth sciences
    - Identify libraries suitable for working with earth-science data
    - Make improvements to these libraries as needed to help improve earth-science workflows
-   
+
 EarthML contains no code of its own, only tutorials and examples
 showing how to use packages like:
 
-   - Data libraries:
-      - `Intake <https://intake.readthedocs.io>`_: Cleanly loading data from various sources.
-      - `XArray <http://xarray.pydata.org>`_: Processing gridded (n-dimensional) data structures.
-      - `Pandas <http://pandas.pydata.org>`_: Processing columnar (tabular) data structures.
-      - `Dask <http://dask.pydata.org>`_: Parallelism and performance at scale.
-   - Visualization libraries:
-      - `hvPlot <http://hvplot.pyviz.org>`_: Simple data-centric API for plotting, building on:
-        - `Bokeh <http://bokeh.pydata.org>`_: Interactive browser-based
-           plotting.
-        - `HoloViews <http://holoviews.org>`_: Easy construction of Bokeh
-           plots for datasets.
-        - `GeoViews <http://geoviews.org>`_: HoloViews with earth-specific
-           projections.
-        - `Datashader <https://github.com/bokeh/datashader>`_: Rendering large
-           datasets into images for display in browsers.
-      - `Panel <https://panel.pyviz.org>`_: Dashboards, apps, and widgets for any library's plots.
-   - Other tools:
-      - `Jupyter <http://jupyter.org/>`_: Reproducible notebooks (source code for all examples on this site)
-      - `Cartopy <https://scitools.org.uk/cartopy>`_: Geographic coordinate reference systems
-      - `Dask <http://dask.pydata.org>`_: Parallelism and performance at scale.
-   - ML tools: (representative only -- use any you like!)
-      - `Scikit-learn <https://scikit-learn.org>`_: General ML for numeric data
-      - `Keras <https://keras.io>`_/ `TensorFlow <https://www.tensorflow.org>`_/ `PyTorch <https://pytorch.org>`_: Deep learning, images
+- **Data libraries:**
+
+  - `Intake <https://intake.readthedocs.io>`_: Cleanly loading data from various sources.
+  - `XArray <http://xarray.pydata.org>`_: Processing gridded (n-dimensional) data structures.
+  - `Pandas <http://pandas.pydata.org>`_: Processing columnar (tabular) data structures.
+  - `Dask <http://dask.pydata.org>`_: Parallelism and performance at scale.
+
+- **Visualization libraries:**
+
+  - `hvPlot <http://hvplot.pyviz.org>`_: Simple data-centric API for plotting, building on:
+
+    - `Bokeh <http://bokeh.pydata.org>`_: Interactive browser-based plotting.
+    - `HoloViews <http://holoviews.org>`_: Easy construction of Bokeh plots for datasets.
+    - `GeoViews <http://geoviews.org>`_: HoloViews with earth-specific projections.
+    - `Datashader <https://github.com/bokeh/datashader>`_: Rendering large datasets into images for display in browsers.
+  - `Panel <https://panel.pyviz.org>`_: Dashboards, apps, and widgets for any library's plots.
+
+- **Other tools:**
+
+  - `Jupyter <http://jupyter.org/>`_: Reproducible notebooks (source code for all examples on this site).
+  - `Cartopy <https://scitools.org.uk/cartopy>`_: Geographic coordinate reference systems.
+  - `Dask <http://dask.pydata.org>`_: Parallelism and performance at scale.
+
+- **ML tools: (representative only -- use any you like!)**
+
+  - `Scikit-learn <https://scikit-learn.org>`_: General ML for numeric data.
+  - `Keras <https://keras.io>`_/ `TensorFlow <https://www.tensorflow.org>`_/ `PyTorch <https://pytorch.org>`_: Deep learning, images.
 
 
 The EarthML `Tutorial <tutorial>`_ offers a general-purpose overview
@@ -52,33 +56,29 @@ learning and related tasks in the Earth sciences, such as:
 
 .. raw:: html
 
-   <div style="display: flex; flex-flow: column">
-      <div style="display: flex; flex-flow: row">
-         <a href="topics/Carbon_Flux.html">
-            <img src="_static/collage/carbon.png" width=95%/>
-         </a>
-         <a href="topics/Heat_and_Trees.html">
-            <img src="_static/collage/trees.png" width=95%/>
-         </a>
-      </div>
-      <br></br>
-      <div style="display: flex; flex-flow: row">
-         <a href="topics/Walker_Lake.html">
-            <img src="_static/collage/walker.png" width=95%/>
-         </a>
-         <a href="topics/Image_Classification.html">
-            <img src="_static/collage/classifier.png" width=95%/>
-         </a>
-      </div>
-      <br></br>
-      <div style="display: flex; flex-flow: row">
-         <a href="topics/Landsat_Spectral_Clustering.html">
-            <img src="_static/collage/cluster.png" width=95%/>
-         </a>
-         <a href="topics/Landsat_Classifier_Ensemble.html">
-            <img src="_static/collage/ensemble.png" width=95%/>
-         </a>
-      </div>
+   <div style="display: grid;
+               grid-template-columns: fit-content(350px) fit-content(350px) fit-content(350px);
+               grid-gap: 20px;
+               padding: 20px;">
+
+      <a href="topics/Carbon_Flux.html" >
+         <img src="_static/collage/carbon.png" />
+      </a>
+      <a href="topics/Heat_and_Trees.html">
+         <img src="_static/collage/trees.png" />
+      </a>
+      <a href="topics/Walker_Lake.html">
+         <img src="_static/collage/walker.png" />
+      </a>
+      <a href="topics/Image_Classification.html" >
+         <img src="_static/collage/classifier.png" />
+      </a>
+      <a href="topics/Landsat_Spectral_Clustering.html"  >
+         <img src="_static/collage/cluster.png" />
+      </a>
+      <a href="topics/Landsat_Classifier_Ensemble.html" >
+         <img src="_static/collage/ensemble.png" />
+      </a>
    </div>
 
 

--- a/doc/topics/index.rst
+++ b/doc/topics/index.rst
@@ -13,6 +13,7 @@ Contents:
    Visualizing and estimating carbon flux at sites using fluxnet data.
 
    .. figure:: ../_static/collage/carbon.png
+      :target: Carbon_Flux.html
       :scale: 30 %
       :alt: Visualizing and estimating carbon flux at sites
 
@@ -21,6 +22,7 @@ Contents:
    Analysis of how trees affect heat distribution in urban areas.
 
    .. figure:: ../_static/collage/trees.png
+      :target: Heat_and_Trees.html
       :scale: 30 %
       :alt: Analysis of how trees affect heat distribution
 
@@ -29,14 +31,16 @@ Contents:
    Visualizing the change in the NDVI over time for a great saline lake.
 
    .. figure:: ../_static/collage/walker.png
+      :target: Walker_Lake.html
       :scale: 30 %
       :alt: Visualizing the change in the NDVI over time
 
 
-* `Image Classification <Image_Classification.html>`_
+* `Image Classification <Landsat_Spectral_Clustering.html>`_
    Classifying satellite images using Keras+TensorFlow.
 
    .. figure:: ../_static/collage/classifier.png
+      :target: Landsat_Spectral_Clustering.html
       :scale: 30 %
       :alt:  Classifying satellite images using Keras+TensorFlow.
 
@@ -45,6 +49,7 @@ Contents:
    Unsupervised clustering of LANDSAT data
 
    .. figure:: ../_static/collage/cluster.png
+      :target: Landsat_Spectral_Clustering.html
       :scale: 30 %
       :alt: Unsupervised clustering of LANDSAT data
 
@@ -53,6 +58,7 @@ Contents:
    A comparison of scikit learn classifiers using LANDSAT 5 and LANDSAT 8 data sets.
 
    .. figure:: ../_static/collage/ensemble.png
+      :target: Landsat_Classifier_Ensemble.html
       :scale: 30 %
       :alt:  A comparison of scikit learn classifiers
 
@@ -65,6 +71,6 @@ Contents:
     Carbon Flux <Carbon_Flux>
     Heat and Trees <Heat_and_Trees>
     Walker Lake <Walker_Lake>
-    Image Classification <Image_Classification.html>
+    Image Classification <Image_Classification>
     Landsat Spectral Clustering <Landsat_Spectral_Clustering>
     Landsat Classifier Ensemble <Landsat_Classifier_Ensemble>


### PR DESCRIPTION
## Fixed:
 - formatting on bullets
 - links on topics index images
 - spacing of thumbnail images on landing page
 - changed the travis instructions to only checkout .ipynb and .json files so that the latest .rst files don't get overwritten on the build.

## Bullets spacing:
<img width="799" alt="screen shot 2018-12-04 at 12 12 16 pm" src="https://user-images.githubusercontent.com/4806877/49460719-01c0e380-f7c0-11e8-97dc-83061436888e.png">

## Thumbnail spacing:
<img width="897" alt="screen shot 2018-12-04 at 12 12 37 pm" src="https://user-images.githubusercontent.com/4806877/49460723-04233d80-f7c0-11e8-9cfe-31032fe2d22c.png">
