### PR TITLE
Experimenting with using git lfs rather than evaluated branch

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+doc/topics/*.ipynb filter=lfs diff=lfs merge=lfs -text
+doc/topics/*.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
-doc/topics/*.ipynb filter=lfs diff=lfs merge=lfs -text
-doc/topics/*.json filter=lfs diff=lfs merge=lfs -text
+doc/**/*.ipynb filter=lfs diff=lfs merge=lfs -text
+doc/**/*.json filter=lfs diff=lfs merge=lfs -text

--- a/.gitignore
+++ b/.gitignore
@@ -107,6 +107,20 @@ earthml/.version
 
 *.DS_Store
 
+# nbsite
+# rst files normally shouldn't be checked in as they should be
+# dynamically built from notebooks
+doc/**/*.rst
+
+# evaluated .ipynb and json should only be checked in if the files 
+# take a long time to run or require large datsets. The following
+# do not meet those criteria so they should be ignored. 
+# NOTE: this will vary by project
+doc/*.ipynb
+doc/*.json
+doc/tutorial/*.ipynb
+doc/tutorial/*.json
+
 # this dir contains the whole website and should not be checked in on master
 builtdocs/
 

--- a/.gitignore
+++ b/.gitignore
@@ -107,12 +107,6 @@ earthml/.version
 
 *.DS_Store
 
-# nbsite
-# these files normally shouldn't be checked in as they should be
-# dynamically built from notebooks
-doc/**/*.rst
-doc/**/*.ipynb
-doc/**/*.json
 # this dir contains the whole website and should not be checked in on master
 builtdocs/
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -52,10 +52,6 @@ jobs:
       <<: *default
       stage: website_release
       env: DESC="website"
-      before_script:
-        - git checkout -b deploy-${TRAVIS_BRANCH}
-        - git fetch https://github.com/$TRAVIS_REPO_SLUG.git evaluated:refs/remotes/evaluated # all large evaluated notebooks and their json files should be checked in to this branch
-        - git checkout evaluated -- 'doc/topics/*.ipynb' 'doc/topics/*.json'  # only check in evaluated topics
       script: doit build_website
 
       deploy:

--- a/doc/topics/00db90876f57447ab1fa0539835d1e3b.json
+++ b/doc/topics/00db90876f57447ab1fa0539835d1e3b.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:44136fa355b3678a1146ad16f7e8649e94fb4fc21fe77e8310c060f61caaff8a
+size 2

--- a/doc/topics/88b812353e434d4db617d7a99952883e.json
+++ b/doc/topics/88b812353e434d4db617d7a99952883e.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9a63245ff6bd50b9362f54b2ed6bf398d744eac6e94e59126e33d8c2b1876b78
+size 6706

--- a/doc/topics/Carbon_Flux.ipynb
+++ b/doc/topics/Carbon_Flux.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f1b76b6294861e8e3b06e52bdac829134dd51571e3e0cd5d8ae71ad209cbf090
+size 9956846

--- a/doc/topics/Heat_and_Trees.ipynb
+++ b/doc/topics/Heat_and_Trees.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:1ff04ab6e0cb51092d007bb4d7ce677ea042562c0ac42645a792c92f85f35ccd
+size 26378316

--- a/doc/topics/Image_Classification.ipynb
+++ b/doc/topics/Image_Classification.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:66bdbd02d4798e2ec8e9396295fc80112ef234773ab32ccf78266e0344ab859e
+size 11420022

--- a/doc/topics/Landsat_Classifier_Ensemble.ipynb
+++ b/doc/topics/Landsat_Classifier_Ensemble.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0996bc23fe6536546388418d8c7e98a645ddf2fd0f4db672b7ddc5ae9db71295
+size 44266

--- a/doc/topics/Landsat_Spectral_Clustering.ipynb
+++ b/doc/topics/Landsat_Spectral_Clustering.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c16e6b2ee25b8cc69ff75fc543960e40e8a9ed8a6130b10c72eff7f77b5a4b6e
+size 35086785

--- a/doc/topics/Walker_Lake.ipynb
+++ b/doc/topics/Walker_Lake.ipynb
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:85075de838540664f98a7ceb27da03ca32b27b89cb82bd79d507ec2ca031532a
+size 9642332

--- a/doc/topics/c5c37a9122f043bd83211bde82ff2cc3.json
+++ b/doc/topics/c5c37a9122f043bd83211bde82ff2cc3.json
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:05e194ba0e69b1540855116a802829c9def367b0e2623a744cb78bf4c461cc15
+size 7290

--- a/dodo.py
+++ b/dodo.py
@@ -90,3 +90,10 @@ def task_build_website():
         'cp doc/topics/*.json builtdocs/topics/ 2>/dev/null || :',
         'cp doc/tutorial/*.json builtdocs/tutorial/ 2>/dev/null || :',
     ]}
+
+def task_serve_website():
+    """Build website using nbsite"""
+    return {'actions':[
+        "cd builtdocs",
+        "python -m http.server",
+    ]}


### PR DESCRIPTION
Having been unhappy with using a separate branch to keep track of evaluated notebooks, I was thinking it would be good to explore git-lfs instead. I think it could work really nicely - I just need to make sure that the right files are being git-lfsed and the others are being ignored. In the case of this repo, only the evaluated topics should be checked in at all. But what is the right way to indicate that. Should we gitignore the evaluated tutorial notebooks? And if so how can we expose that to the package maintainer. Ideally I think the .gitattributes should be the same across all projects, and the .gitignore should be the one to change. 