### PR TITLE
Add pip as an explicit dependency

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -27,5 +27,6 @@ dependencies:
   - xarray
   - keras
   - defaults::scipy
+  - pip
   - pip:
     - rio-toa


### PR DESCRIPTION
Creating the conda enviroment according to the installation instructions leads to a warning related to pip:

    $ conda env create -f environment.yml
    Warning: you have pip-installed dependencies in your environment file, but you do not list pip itself as one of your conda dependencies.  Conda may not use the correct pip to install your packages, and they may end up in the wrong place.  Please add an explicit pip dependency.  I'm adding one for you, but still nagging you.

Including `pip` in the environment prevents this warning, avoids any ambiguity surrounding pip dependencies, and conforms to the [best practices](https://docs.conda.io/projects/conda/en/latest/user-guide/tasks/manage-pkgs.html#installing-non-conda-packages) as I interpret them.