### PR TITLE
fix downsampling bug in docs

### DIFF
--- a/examples/tutorial/03_Alignment_and_Preprocessing.ipynb
+++ b/examples/tutorial/03_Alignment_and_Preprocessing.ipynb
@@ -388,8 +388,8 @@
    "outputs": [],
    "source": [
     "res_1000 = 1e3\n",
-    "x_1000 = np.arange(xmin, xmax, res)\n",
-    "y_1000 = np.arange(ymin, ymax, res)"
+    "x_1000 = np.arange(xmin, xmax, res_1000)\n",
+    "y_1000 = np.arange(ymin, ymax, res_1000)"
    ]
   },
   {
@@ -402,12 +402,14 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
+   "metadata": {
+    "scrolled": false
+   },
    "outputs": [],
    "source": [
     "diff_res_1000 = (diff_regridded\n",
-    "    .groupby_bins('x', x_1000, labels=x[:-1]).mean(dim='x')\n",
-    "    .groupby_bins('y', y_1000, labels=y[:-1]).mean(dim='y')\n",
+    "    .groupby_bins('x', x_1000, labels=x_1000[:-1]).mean(dim='x')\n",
+    "    .groupby_bins('y', y_1000, labels=y_1000[:-1]).mean(dim='y')\n",
     "    .rename(x_bins='x', y_bins='y')\n",
     ")\n",
     "diff_res_1000"
@@ -440,9 +442,22 @@
   }
  ],
  "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
   "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
    "name": "python",
-   "pygments_lexer": "ipython3"
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.3"
   }
  },
  "nbformat": 4,

--- a/examples/tutorial/03_Alignment_and_Preprocessing.ipynb
+++ b/examples/tutorial/03_Alignment_and_Preprocessing.ipynb
@@ -442,22 +442,9 @@
   }
  ],
  "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
   "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
    "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.7.3"
+   "pygments_lexer": "ipython3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This fixes #96.

Note: There is another line in this tutorial that is currently broken due to a bug in geoviews with pyproj >= 2.0: 

```
crs = gv.util.proj_to_cartopy(landsat_8_da.crs)
```

I've submitted a PR to geoviews to fix it: https://github.com/pyviz/geoviews/pull/376
