### PR TITLE
Fix PYENV_VERSION on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ cache:
 
 env:
   global:
-    - PYENV_VERSION=3.6
+    - PYTHON_VERSION=3.7
 
 stages:
   - test


### PR DESCRIPTION
Apparently PYENV_VERSION needs to become PYTHON_VERSION for Travis CI to be happy.  Also updated Python from 3.6 to 3.7, which shouldn't be an issue for any of the libraries used, but one never knows.